### PR TITLE
module files placed in install directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,10 @@ ecbuild_add_executable( TARGET   mom6.x
                         LINKER_LANGUAGE ${MOM6_LINKER_LANGUAGE}
                        )
 
+if(ECBUILD_INSTALL_FORTRAN_MODULES)
+  install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/${CMAKE_CFG_INTDIR} DESTINATION ${INSTALL_INCLUDE_DIR})
+endif()
+
 ################################################################################
 # Finalise configuration
 ################################################################################


### PR DESCRIPTION
fortran module files were not placed correctly when doing a `make install`