### PR TITLE
Simple bugfix related to -DENABLE_OCEAN_BGC

### DIFF
--- a/config_src/CMakeLists.txt
+++ b/config_src/CMakeLists.txt
@@ -10,7 +10,7 @@ config_src/solo_driver/MOM_surface_forcing.F90
 config_src/solo_driver/user_surface_forcing.F90
 )
 
-if (NOT ${ENABLE_OCEAN_BGC})
+if ( NOT ENABLE_OCEAN_BGC )
     list ( APPEND _files
     config_src/external/GFDL_ocean_BGC/generic_tracer.F90
     config_src/external/GFDL_ocean_BGC/generic_tracer_utils.F90


### PR DESCRIPTION
## Description

When (ec)building mom6, succeeded with -DENABLE_OCEAN_BGC=ON and -DENABLE_OCEAN_BGC=OFF but failed when -DENABLE_OCEAN_BGC if not specified in the ecbuild command line.
It is related to a bug in config_src/CMakelist.txt; the solution provided in this PR is to replace
`if ( NOT ${ENABLE_OCEAN_BGC})`
with:
`if ( NOT ENABLE_OCEAN_BGC)`
which should solve the problem. (Sorry! It was my mistake!)

### Issue(s) addressed

- fixes #21
